### PR TITLE
Fix infinite image scaling bug

### DIFF
--- a/lib/widgets/inline_image.dart
+++ b/lib/widgets/inline_image.dart
@@ -35,6 +35,9 @@ class _InlineImageState extends State<InlineImage> {
                 child: PhotoView(
                   imageProvider: image,
                   backgroundDecoration: const BoxDecoration(color: Colors.black),
+                  minScale: PhotoViewComputedScale.contained * 0.5,
+                  maxScale: PhotoViewComputedScale.covered * 3.0,
+                  initialScale: PhotoViewComputedScale.contained,
                 ),
               ),
               Positioned(


### PR DESCRIPTION
Prevent infinite image scaling by adding `minScale` and `maxScale` to PhotoView.